### PR TITLE
Use the existing subscription_name variable

### DIFF
--- a/tag_rule/main.tf
+++ b/tag_rule/main.tf
@@ -26,7 +26,7 @@ resource "polaris_tag_rule" "rule" {
 # Match all Azure VMs which has a tag called my-key with the value my-value in
 # the my-azure-subscription RSC cloud account.
 data "polaris_azure_subscription" "subscription" {
-  name = "my-azure-subscription"
+  name = var.subscription_name
 }
 
 resource "polaris_tag_rule" "rule" {


### PR DESCRIPTION
# Description

The example declared a `subscription_name` input variable, but still hardcoded the name of the subscription. Use the existing variable instead.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
