### PR TITLE
Simplify .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,4 @@
-# Prevent accidental commit of service accounts or service principals
 *.json
-
-.terraform
-.terraform.lock.hcl
-.terraform.tfstate.lock.info
-terraform.tfstate
-terraform.tfstate.backup
-terraform.tfstate*
 *.tfvars
+.terraform*
+terraform.tfstate*


### PR DESCRIPTION
# Description

Replace redundant `.gitignore` entries with glob patterns and remove a comment that was not adding any value.

## Related Issue

N/A

## Motivation and Context

The `.gitignore` had explicit entries for files already covered by existing glob patterns, e.g. `terraform.tfstate`
and `terraform.tfstate.backup` were listed alongside `terraform.tfstate*` which already covers both.

## How Has This Been Tested?

Verified with `git status` that the same files are still ignored.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.