### PR TITLE
Add CIDR format validation to exocompute_vpc submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@
 * Add support for the `CLOUD_DISCOVERY` feature to the `aws_iam_account` module.
 * Add support for private Exocompute to the `aws_exocompute` module.
 * Add support for pod subnets to the `aws_exocompute` module.
+* Add CIDR format validation to the `aws_exocompute` module's `exocompute_vpc` submodule.

--- a/modules/aws_exocompute/modules/exocompute_vpc/variables.tf
+++ b/modules/aws_exocompute/modules/exocompute_vpc/variables.tf
@@ -6,22 +6,42 @@ variable "name" {
 variable "public_cidr" {
   description = "CIDR for the public subnet."
   type        = string
+
+  validation {
+    condition     = can(cidrhost(var.public_cidr, 0))
+    error_message = "Public subnet CIDR must be a valid CIDR block."
+  }
 }
 
 variable "subnet1_cidr" {
   description = "CIDR for subnet 1."
   type        = string
+
+  validation {
+    condition     = can(cidrhost(var.subnet1_cidr, 0))
+    error_message = "Subnet 1 CIDR must be a valid CIDR block."
+  }
 }
 
 variable "subnet2_cidr" {
   description = "CIDR for subnet 2."
   type        = string
+
+  validation {
+    condition     = can(cidrhost(var.subnet2_cidr, 0))
+    error_message = "Subnet 2 CIDR must be a valid CIDR block."
+  }
 }
 
 variable "pod_subnet1_cidr" {
   description = "CIDR for pod subnet 1."
   type        = string
   default     = null
+
+  validation {
+    condition     = var.pod_subnet1_cidr == null || can(cidrhost(var.pod_subnet1_cidr, 0))
+    error_message = "Pod subnet 1 CIDR must be a valid CIDR block."
+  }
 }
 
 variable "pod_subnet2_cidr" {
@@ -29,6 +49,10 @@ variable "pod_subnet2_cidr" {
   type        = string
   default     = null
 
+  validation {
+    condition     = var.pod_subnet2_cidr == null || can(cidrhost(var.pod_subnet2_cidr, 0))
+    error_message = "Pod subnet 2 CIDR must be a valid CIDR block."
+  }
   validation {
     condition     = (var.pod_subnet1_cidr == null) == (var.pod_subnet2_cidr == null)
     error_message = "Pod subnet1 CIDR and pod subnet2 CIDR must be specified together."
@@ -38,6 +62,11 @@ variable "pod_subnet2_cidr" {
 variable "vpc_cidr" {
   description = "CIDR for the VPC."
   type        = string
+
+  validation {
+    condition     = can(cidrhost(var.vpc_cidr, 0))
+    error_message = "VPC CIDR must be a valid CIDR block."
+  }
 }
 
 variable "tags" {


### PR DESCRIPTION
# Description

Add `can(cidrhost(..., 0))` validation blocks to all 6 CIDR variables in the `exocompute_vpc` submodule (`vpc_cidr`, `public_cidr`, `subnet1_cidr`, `subnet2_cidr`, `pod_subnet1_cidr`, `pod_subnet2_cidr`). This catches invalid CIDR values at `terraform plan` time rather than at apply time when the AWS API rejects them.

## Related Issue

N/A

## Motivation and Context

The `exocompute_vpc` submodule accepts 6 CIDR block variables but none of them validated that the provided values are actually valid CIDR notation. Invalid values would only be caught later when the AWS API rejected them, producing less helpful error messages.

## How Has This Been Tested?

Tested by running the module tests.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.