### PR TITLE
Add AWS role chaining support to aws_iam_account module

### DIFF
--- a/modules/aws_iam_account/README.md
+++ b/modules/aws_iam_account/README.md
@@ -76,24 +76,24 @@ module "aws_iam_account" {
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.11.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=6.0.0 |
-| <a name="requirement_polaris"></a> [polaris](#requirement\_polaris) | >=1.5.0 |
+| <a name="requirement_polaris"></a> [polaris](#requirement\_polaris) | >=1.6.3 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >=0.13.1 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >=6.0.0 |
-| <a name="provider_polaris"></a> [polaris](#provider\_polaris) | >=1.5.0 |
+| <a name="provider_polaris"></a> [polaris](#provider\_polaris) | >=1.6.3 |
 | <a name="provider_time"></a> [time](#provider\_time) | >=0.13.1 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_iam_instance_profile.profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_policy.customer_managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.customer_inline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -114,15 +114,16 @@ module "aws_iam_account" {
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_account_id"></a> [account\_id](#input\_account\_id) | AWS account ID. | `string` | n/a | yes |
 | <a name="input_account_name"></a> [account\_name](#input\_account\_name) | AWS account name. | `string` | n/a | yes |
 | <a name="input_cloud_type"></a> [cloud\_type](#input\_cloud\_type) | AWS cloud type. Possible values are: STANDARD, GOV. Defaults to STANDARD. | `string` | `null` | no |
 | <a name="input_ec2_recovery_role_path"></a> [ec2\_recovery\_role\_path](#input\_ec2\_recovery\_role\_path) | AWS EC2 recovery role path. | `string` | `null` | no |
 | <a name="input_exocompute_host_id"></a> [exocompute\_host\_id](#input\_exocompute\_host\_id) | RSC cloud account ID (UUID) of the AWS account hosting Exocompute. | `string` | `null` | no |
 | <a name="input_external_id"></a> [external\_id](#input\_external\_id) | AWS external ID. If empty, RSC will automatically generate an external ID. | `string` | `null` | no |
-| <a name="input_features"></a> [features](#input\_features) | RSC features with permission groups. Possible features are: CLOUD\_DISCOVERY, CLOUD\_NATIVE\_ARCHIVAL, CLOUD\_NATIVE\_DYNAMODB\_PROTECTION, CLOUD\_NATIVE\_PROTECTION, CLOUD\_NATIVE\_S3\_PROTECTION, EXOCOMPUTE, KUBERNETES\_PROTECTION, RDS\_PROTECTION and SERVERS\_AND\_APPS. | <pre>map(object({<br/>    permission_groups = set(string)<br/>  }))</pre> | n/a | yes |
+| <a name="input_features"></a> [features](#input\_features) | RSC features with permission groups. Possible features are: CLOUD\_DISCOVERY, CLOUD\_NATIVE\_ARCHIVAL, CLOUD\_NATIVE\_DYNAMODB\_PROTECTION, CLOUD\_NATIVE\_PROTECTION, CLOUD\_NATIVE\_S3\_PROTECTION, EXOCOMPUTE, KUBERNETES\_PROTECTION, RDS\_PROTECTION, ROLE\_CHAINING and SERVERS\_AND\_APPS. | <pre>map(object({<br/>    permission_groups = set(string)<br/>  }))</pre> | n/a | yes |
 | <a name="input_regions"></a> [regions](#input\_regions) | AWS regions to onboard. | `set(string)` | n/a | yes |
+| <a name="input_role_chaining_account_id"></a> [role\_chaining\_account\_id](#input\_role\_chaining\_account\_id) | RSC cloud account ID (UUID) of the role chaining account. When specified, the account will use cross-account role chaining. | `string` | `null` | no |
 | <a name="input_role_path"></a> [role\_path](#input\_role\_path) | AWS role path. Defaults to '/'. | `string` | `"/"` | no |
 | <a name="input_role_type"></a> [role\_type](#input\_role\_type) | How the AWS policies should be attached to the IAM roles created for RSC. Possible values: `managed`, `inline` and `legacy`. `legacy` should only be used for backwards compatibility with previously onboarded AWS accounts. | `string` | `"managed"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to AWS resources created. | `map(string)` | <pre>{<br/>  "Module": "aws_iam_account",<br/>  "Repository": "github.com/rubrikinc/terraform-provider-polaris-examples"<br/>}</pre> | no |
@@ -130,6 +131,6 @@ module "aws_iam_account" {
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_cloud_account_id"></a> [cloud\_account\_id](#output\_cloud\_account\_id) | RSC cloud account ID for the AWS account. |
 <!-- END_TF_DOCS -->

--- a/modules/aws_iam_account/examples/basic/README.md
+++ b/modules/aws_iam_account/examples/basic/README.md
@@ -17,20 +17,20 @@ resources.
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=6.0.0 |
-| <a name="requirement_polaris"></a> [polaris](#requirement\_polaris) | >=1.5.0 |
+| <a name="requirement_polaris"></a> [polaris](#requirement\_polaris) | >=1.6.3 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_aws_iam_account"></a> [aws\_iam\_account](#module\_aws\_iam\_account) | ../.. | n/a |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_account_id"></a> [account\_id](#input\_account\_id) | AWS account ID. | `string` | n/a | yes |
 | <a name="input_account_name"></a> [account\_name](#input\_account\_name) | AWS account name. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to AWS resources created. | `map(string)` | <pre>{<br/>  "Example": "basic",<br/>  "Module": "aws_iam_account",<br/>  "Repository": "github.com/rubrikinc/terraform-provider-polaris-examples"<br/>}</pre> | no |

--- a/modules/aws_iam_account/examples/basic/main.tf
+++ b/modules/aws_iam_account/examples/basic/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     polaris = {
       source  = "rubrikinc/polaris"
-      version = ">=1.5.0"
+      version = ">=1.6.3"
     }
   }
 }

--- a/modules/aws_iam_account/examples/shared_exocompute/README.md
+++ b/modules/aws_iam_account/examples/shared_exocompute/README.md
@@ -18,20 +18,20 @@ resources.
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=6.0.0 |
 | <a name="requirement_polaris"></a> [polaris](#requirement\_polaris) | >=1.5.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_aws_iam_account"></a> [aws\_iam\_account](#module\_aws\_iam\_account) | ../.. | n/a |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_account_id"></a> [account\_id](#input\_account\_id) | AWS account ID. | `string` | n/a | yes |
 | <a name="input_account_name"></a> [account\_name](#input\_account\_name) | AWS account name. | `string` | n/a | yes |
 | <a name="input_exocompute_host_id"></a> [exocompute\_host\_id](#input\_exocompute\_host\_id) | RSC cloud account ID (UUID) of the AWS account hosting Exocompute. | `string` | n/a | yes |

--- a/modules/aws_iam_account/main.tf
+++ b/modules/aws_iam_account/main.tf
@@ -35,11 +35,12 @@ data "polaris_aws_cnp_permissions" "permissions" {
 
 # Create the RSC AWS cloud account.
 resource "polaris_aws_cnp_account" "account" {
-  cloud       = var.cloud_type
-  external_id = var.external_id
-  name        = var.account_name
-  native_id   = var.account_id
-  regions     = var.regions
+  cloud                    = var.cloud_type
+  external_id              = var.external_id
+  name                     = var.account_name
+  native_id                = var.account_id
+  regions                  = var.regions
+  role_chaining_account_id = var.role_chaining_account_id
 
   dynamic "feature" {
     for_each = var.features
@@ -52,8 +53,9 @@ resource "polaris_aws_cnp_account" "account" {
 
 # Attach the instance profiles and the roles to the RSC cloud account.
 resource "polaris_aws_cnp_account_attachments" "attachments" {
-  account_id = polaris_aws_cnp_account.account.id
-  features   = keys(var.features)
+  account_id               = polaris_aws_cnp_account.account.id
+  features                 = keys(var.features)
+  role_chaining_account_id = var.role_chaining_account_id
 
   dynamic "instance_profile" {
     for_each = aws_iam_instance_profile.profile

--- a/modules/aws_iam_account/terraform.tf
+++ b/modules/aws_iam_account/terraform.tf
@@ -6,7 +6,7 @@ terraform {
     }
     polaris = {
       source  = "rubrikinc/polaris"
-      version = ">=1.5.0"
+      version = ">=1.6.3"
     }
     time = {
       source  = "hashicorp/time"

--- a/modules/aws_iam_account/variables.tf
+++ b/modules/aws_iam_account/variables.tf
@@ -8,6 +8,7 @@ locals {
     "EXOCOMPUTE",
     "KUBERNETES_PROTECTION",
     "RDS_PROTECTION",
+    "ROLE_CHAINING",
     "SERVERS_AND_APPS",
   ]
 
@@ -41,6 +42,10 @@ locals {
   ]
 
   rds_protection = [
+    "BASIC",
+  ]
+
+  role_chaining = [
     "BASIC",
   ]
 
@@ -108,8 +113,19 @@ variable "external_id" {
   }
 }
 
+variable "role_chaining_account_id" {
+  description = "RSC cloud account ID (UUID) of the role chaining account. When specified, the account will use cross-account role chaining."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.role_chaining_account_id == null || can(regex(local.uuid_regex, var.role_chaining_account_id))
+    error_message = "Invalid role chaining account ID. Must be a valid UUID."
+  }
+}
+
 variable "features" {
-  description = "RSC features with permission groups. Possible features are: CLOUD_DISCOVERY, CLOUD_NATIVE_ARCHIVAL, CLOUD_NATIVE_DYNAMODB_PROTECTION, CLOUD_NATIVE_PROTECTION, CLOUD_NATIVE_S3_PROTECTION, EXOCOMPUTE, KUBERNETES_PROTECTION, RDS_PROTECTION and SERVERS_AND_APPS."
+  description = "RSC features with permission groups. Possible features are: CLOUD_DISCOVERY, CLOUD_NATIVE_ARCHIVAL, CLOUD_NATIVE_DYNAMODB_PROTECTION, CLOUD_NATIVE_PROTECTION, CLOUD_NATIVE_S3_PROTECTION, EXOCOMPUTE, KUBERNETES_PROTECTION, RDS_PROTECTION, ROLE_CHAINING and SERVERS_AND_APPS."
   type = map(object({
     permission_groups = set(string)
   }))
@@ -149,6 +165,10 @@ variable "features" {
   validation {
     condition     = length(setsubtract(try(var.features["RDS_PROTECTION"].permission_groups, []), local.rds_protection)) == 0
     error_message = format("Invalid permission groups for RSC feature. Allowed permission groups are: %v.", join(", ", local.rds_protection))
+  }
+  validation {
+    condition     = length(setsubtract(try(var.features["ROLE_CHAINING"].permission_groups, []), local.role_chaining)) == 0
+    error_message = format("Invalid permission groups for RSC feature. Allowed permission groups are: %v.", join(", ", local.role_chaining))
   }
   validation {
     condition     = length(setsubtract(try(var.features["SERVERS_AND_APPS"].permission_groups, []), local.servers_and_apps)) == 0


### PR DESCRIPTION
# Description

Add AWS role chaining support to the `aws_iam_account` module. This adds an optional `role_chaining_account_id` variable and passes it to both the account and attachments resources. Also adds `ROLE_CHAINING` as a valid feature with `BASIC` permission group validation.

## Related Issue

Depends on rubrikinc/terraform-provider-polaris#429.

## Motivation and Context

AWS role chaining introduces a mediator account between RSC and customer AWS accounts. The example module needs to accept an optional role chaining account ID so that users can onboard both the role chaining account itself and accounts linked to it.

## How Has This Been Tested?

Manually tested against a dev RSC instance by onboarding a role chaining account and a mapped account.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
