### PR TITLE
Add v1.2.0 changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.2.0
+* Add support for AWS role chaining to the `aws_iam_account` module.
+* Add CIDR format validation to the `aws_exocompute` module's `exocompute_vpc` submodule.
+
 ## v1.1.0
 * Add `gcp_project` Terraform module.
 * Add `gcp_archival_location` Terraform module.
@@ -15,4 +19,3 @@
 * Add support for the `CLOUD_DISCOVERY` feature to the `aws_iam_account` module.
 * Add support for private Exocompute to the `aws_exocompute` module.
 * Add support for pod subnets to the `aws_exocompute` module.
-* Add CIDR format validation to the `aws_exocompute` module's `exocompute_vpc` submodule.


### PR DESCRIPTION
# Description

Add a v1.2.0 section to the changelog with the role chaining and CIDR validation entries. Move the CIDR validation entry from v1.1.0 where it was listed but not included in the release.

## Motivation and Context

Preparing for the v1.2.0 release of the examples repo to accompany the Terraform provider v1.6.3 releases.

## How Has This Been Tested?

Documentation-only change, no code modified.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.