### PR TITLE
Add role chaining example to aws_iam_account module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.2.0
 * Add support for AWS role chaining to the `aws_iam_account` module.
 * Add CIDR format validation to the `aws_exocompute` module's `exocompute_vpc` submodule.
+* Add role chaining example to the `aws_iam_account` module.
 
 ## v1.1.0
 * Add `gcp_project` Terraform module.
@@ -19,3 +20,4 @@
 * Add support for the `CLOUD_DISCOVERY` feature to the `aws_iam_account` module.
 * Add support for private Exocompute to the `aws_exocompute` module.
 * Add support for pod subnets to the `aws_exocompute` module.
+

--- a/modules/aws_iam_account/examples/role_chaining/README.md
+++ b/modules/aws_iam_account/examples/role_chaining/README.md
@@ -1,0 +1,45 @@
+# Role Chaining
+
+The configuration in this directory adds two AWS accounts to RSC using the IAM roles workflow. The first account is
+onboarded with the `ROLE_CHAINING` feature, and the second account is onboarded as a role-chained account, using the
+first account's cloud account ID as the `role_chaining_account_id`.
+
+Each account uses its own aliased AWS provider with a separate named profile (`role-chaining` and `role-chained`),
+allowing the two accounts to use different credentials. Update the profile names to match your AWS CLI configuration.
+
+## Usage
+
+To run this example you need to execute:
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+Note that this example may create resources which can cost money. Run `terraform destroy` when you don't need these
+resources.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=6.0.0 |
+| <a name="requirement_polaris"></a> [polaris](#requirement\_polaris) | >=1.6.3 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_role_chained_account"></a> [role\_chained\_account](#module\_role\_chained\_account) | ../.. | n/a |
+| <a name="module_role_chaining_account"></a> [role\_chaining\_account](#module\_role\_chaining\_account) | ../.. | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_role_chained_account_id"></a> [role\_chained\_account\_id](#input\_role\_chained\_account\_id) | AWS account ID for the role-chained account. | `string` | n/a | yes |
+| <a name="input_role_chained_account_name"></a> [role\_chained\_account\_name](#input\_role\_chained\_account\_name) | AWS account name for the role-chained account. | `string` | n/a | yes |
+| <a name="input_role_chaining_account_id"></a> [role\_chaining\_account\_id](#input\_role\_chaining\_account\_id) | AWS account ID for the role-chaining account. | `string` | n/a | yes |
+| <a name="input_role_chaining_account_name"></a> [role\_chaining\_account\_name](#input\_role\_chaining\_account\_name) | AWS account name for the role-chaining account. | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to AWS resources created. | `map(string)` | <pre>{<br/>  "Example": "role_chaining",<br/>  "Module": "aws_iam_account",<br/>  "Repository": "github.com/rubrikinc/terraform-provider-polaris-examples"<br/>}</pre> | no |
+<!-- END_TF_DOCS -->

--- a/modules/aws_iam_account/examples/role_chaining/main.tf
+++ b/modules/aws_iam_account/examples/role_chaining/main.tf
@@ -1,0 +1,112 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=6.0.0"
+    }
+    polaris = {
+      source  = "rubrikinc/polaris"
+      version = ">=1.6.3"
+    }
+  }
+}
+
+variable "role_chaining_account_id" {
+  type        = string
+  description = "AWS account ID for the role-chaining account."
+}
+
+variable "role_chaining_account_name" {
+  type        = string
+  description = "AWS account name for the role-chaining account."
+}
+
+variable "role_chained_account_id" {
+  type        = string
+  description = "AWS account ID for the role-chained account."
+}
+
+variable "role_chained_account_name" {
+  type        = string
+  description = "AWS account name for the role-chained account."
+}
+
+variable "tags" {
+  description = "Tags to apply to AWS resources created."
+  type        = map(string)
+  default = {
+    Example    = "role_chaining"
+    Module     = "aws_iam_account"
+    Repository = "github.com/rubrikinc/terraform-provider-polaris-examples"
+  }
+}
+
+provider "aws" {
+  alias   = "role_chaining_provider"
+  profile = "role-chaining"
+}
+
+provider "aws" {
+  alias   = "role_chained_provider"
+  profile = "role-chained"
+}
+
+module "role_chaining_account" {
+  source    = "../.."
+  providers = {
+    aws = aws.role_chaining_provider,
+  }
+
+  account_id   = var.role_chaining_account_id
+  account_name = var.role_chaining_account_name
+
+  features = {
+    ROLE_CHAINING = {
+      permission_groups = [
+        "BASIC",
+      ]
+    },
+  }
+
+  regions = [
+    "us-east-2",
+  ]
+
+  tags = var.tags
+}
+
+module "role_chained_account" {
+  source    = "../.."
+  providers = {
+    aws = aws.role_chained_provider,
+  }
+
+  account_id               = var.role_chained_account_id
+  account_name             = var.role_chained_account_name
+  role_chaining_account_id = module.role_chaining_account.cloud_account_id
+
+  features = {
+    CLOUD_DISCOVERY = {
+      permission_groups = [
+        "BASIC",
+      ]
+    },
+    CLOUD_NATIVE_PROTECTION = {
+      permission_groups = [
+        "BASIC",
+      ]
+    },
+    EXOCOMPUTE = {
+      permission_groups = [
+        "BASIC",
+        "RSC_MANAGED_CLUSTER",
+      ]
+    },
+  }
+
+  regions = [
+    "us-east-2",
+  ]
+
+  tags = var.tags
+}


### PR DESCRIPTION
# Description

Add an example showing how to onboard two AWS accounts using role chaining with aliased providers for separate credentials.

## How Has This Been Tested?

By manually running the example to deploy a role-chaining account and role-chained account.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
