### PR TITLE
Add Other category to PR template Types of changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,6 +28,7 @@ What types of changes does your code introduce? Put an `x` in all the boxes that
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Other (please describe in the Description above)
 
 ## Checklist:
 


### PR DESCRIPTION
# Description

Adds an ``Other`` line to the ``Types of changes`` section of the PR template so that documentation, refactor, dep bump, CI, and similar non-code-impact PRs have a category to tick. The existing three options (Bug fix, New feature, Breaking change) are all framed as code-impact categories and leave such PRs with nothing to check; the unticked state then reads ambiguously as either docs-only or "the author forgot."

## Related Issue

N/A.

## Motivation and Context

Came up while preparing the v1.7.0 docs PRs in the polaris and rubrik provider repos. The same template lives in this repo and the Go SDK, so applying the same fix here keeps all four repos in sync. Adding ``Other`` is the lightest-touch fix and avoids creeping toward a long list (``Documentation``, ``Refactor``, ``Chore``, ``CI``, ``Tests``, ...). The PR description is expected to clarify what the change actually is.

## How Has This Been Tested?

N/A — single-line change to a markdown template.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an \`x\` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (please describe in the Description above)

## Checklist:

Go over all the following points, and put an \`x\` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.