### PR TITLE
Fix duplicate policy name collision in aws_iam_account module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.2.1
+* Fix a bug in the `aws_iam_account` module where two RSC policies sharing a name within the same role artifact
+  caused a Terraform duplicate-key error. Colliding policies are now suffixed with a short hash of the policy body.
+
 ## v1.2.0
 * Add support for AWS role chaining to the `aws_iam_account` module.
 * Add CIDR format validation to the `aws_exocompute` module's `exocompute_vpc` submodule.

--- a/modules/aws_iam_account/iam_roles.tf
+++ b/modules/aws_iam_account/iam_roles.tf
@@ -1,9 +1,14 @@
 locals {
+  # When two policies in the same RSC role artifact share a name, suffix the
+  # colliding entries with a short hash of the policy body to keep map keys
+  # unique. Names that don't collide pass through unchanged.
   customer_managed_policies = merge([
     for key, value in data.polaris_aws_cnp_permissions.permissions : {
-      for policy in value.customer_managed_policies : policy.name => {
-        role_key = key,
-        policy   = policy.policy,
+      for p in value.customer_managed_policies : (
+        length([for v in value.customer_managed_policies : v if v.name == p.name]) == 1 ? p.name : "${p.name}-${substr(sha256(p.policy), 0, 8)}"
+      ) => {
+        role_key = key
+        policy   = p.policy
       }
     }
   ]...)
@@ -113,6 +118,6 @@ resource "aws_iam_role_policy_attachments_exclusive" "customer_managed" {
 
   policy_arns = concat(
     each.value.managed_policies,
-    [for policy in each.value.customer_managed_policies : aws_iam_policy.customer_managed[policy.name].arn]
+    [for k, v in local.customer_managed_policies : aws_iam_policy.customer_managed[k].arn if v.role_key == each.key]
   )
 }

--- a/modules/aws_iam_account/iam_roles.tf
+++ b/modules/aws_iam_account/iam_roles.tf
@@ -5,7 +5,11 @@ locals {
   customer_managed_policies = merge([
     for key, value in data.polaris_aws_cnp_permissions.permissions : {
       for p in value.customer_managed_policies : (
-        length([for v in value.customer_managed_policies : v if v.name == p.name]) == 1 ? p.name : "${p.name}-${substr(sha256(p.policy), 0, 8)}"
+        # A count higher than 1 means there is a collision and the key is
+        # suffixed with a short hash of the body; a count of 1 means p is the
+        # only policy with that name, so the bare name is safe to use as the
+        # key.
+        length([for v in value.customer_managed_policies : v if v.name == p.name]) > 1 ? "${p.name}-${substr(sha256(p.policy), 0, 8)}" : p.name
       ) => {
         role_key = key
         policy   = p.policy


### PR DESCRIPTION
# Description

The `aws_iam_account` module's `iam_roles.tf` builds a flat `customer_managed_policies` map keyed by `policy.name`. RSC can return two customer-managed policies with the same name within a single role artifact (observed: two `ExocomputePolicy` entries under `CROSSACCOUNT` with different bodies), which hit Terraform's duplicate-key error and aborted the apply.

This change suffixes only the colliding entries with the first 8 characters of `sha256(policy.policy)`. Names that don't collide pass through unchanged, so existing customer state is preserved. The `aws_iam_role_policy_attachments_exclusive.customer_managed` lookup now filters the flat local by `role_key` instead of looking up by raw `policy.name`, so the disambiguation rule lives in exactly one place.

## Related Issue

_None._

## Motivation and Context

Without this fix, any tenant where RSC returns same-named customer-managed policies in a single role artifact cannot apply the `aws_iam_account` module. After the fix, those tenants get one AWS IAM policy per distinct body, while unaffected tenants see no state churn.

## How Has This Been Tested?

* End-to-end against an RSC tenant without collisions to confirm no state churn for unaffected tenants.
* Offline via mocked permission data to reproduce the CROSSACCOUNT `ExocomputePolicy` collision and verify the merge expression produces the expected disambiguated keys.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (please describe in the Description above)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.