### PR TITLE
Add external_id variables to the role_chaining example

### DIFF
--- a/modules/aws_iam_account/examples/role_chaining/README.md
+++ b/modules/aws_iam_account/examples/role_chaining/README.md
@@ -37,8 +37,10 @@ resources.
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_role_chained_account_external_id"></a> [role\_chained\_account\_external\_id](#input\_role\_chained\_account\_external\_id) | External ID for the role-chained account. | `string` | `null` | no |
 | <a name="input_role_chained_account_id"></a> [role\_chained\_account\_id](#input\_role\_chained\_account\_id) | AWS account ID for the role-chained account. | `string` | n/a | yes |
 | <a name="input_role_chained_account_name"></a> [role\_chained\_account\_name](#input\_role\_chained\_account\_name) | AWS account name for the role-chained account. | `string` | n/a | yes |
+| <a name="input_role_chaining_account_external_id"></a> [role\_chaining\_account\_external\_id](#input\_role\_chaining\_account\_external\_id) | External ID for the role-chaining account. | `string` | `null` | no |
 | <a name="input_role_chaining_account_id"></a> [role\_chaining\_account\_id](#input\_role\_chaining\_account\_id) | AWS account ID for the role-chaining account. | `string` | n/a | yes |
 | <a name="input_role_chaining_account_name"></a> [role\_chaining\_account\_name](#input\_role\_chaining\_account\_name) | AWS account name for the role-chaining account. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to AWS resources created. | `map(string)` | <pre>{<br/>  "Example": "role_chaining",<br/>  "Module": "aws_iam_account",<br/>  "Repository": "github.com/rubrikinc/terraform-provider-polaris-examples"<br/>}</pre> | no |

--- a/modules/aws_iam_account/examples/role_chaining/main.tf
+++ b/modules/aws_iam_account/examples/role_chaining/main.tf
@@ -21,6 +21,12 @@ variable "role_chaining_account_name" {
   description = "AWS account name for the role-chaining account."
 }
 
+variable "role_chaining_account_external_id" {
+  type        = string
+  description = "External ID for the role-chaining account."
+  default     = null
+}
+
 variable "role_chained_account_id" {
   type        = string
   description = "AWS account ID for the role-chained account."
@@ -29,6 +35,12 @@ variable "role_chained_account_id" {
 variable "role_chained_account_name" {
   type        = string
   description = "AWS account name for the role-chained account."
+}
+
+variable "role_chained_account_external_id" {
+  type        = string
+  description = "External ID for the role-chained account."
+  default     = null
 }
 
 variable "tags" {
@@ -59,6 +71,7 @@ module "role_chaining_account" {
 
   account_id   = var.role_chaining_account_id
   account_name = var.role_chaining_account_name
+  external_id  = var.role_chaining_account_external_id
 
   features = {
     ROLE_CHAINING = {
@@ -83,6 +96,7 @@ module "role_chained_account" {
 
   account_id               = var.role_chained_account_id
   account_name             = var.role_chained_account_name
+  external_id              = var.role_chained_account_external_id
   role_chaining_account_id = module.role_chaining_account.cloud_account_id
 
   features = {


### PR DESCRIPTION
# Description

Expose the `external_id` input on both account modules in the `role_chaining` example so the example shows how the attribute is wired through. Both variables default to `null`, matching the previous behavior of letting RSC generate the external ID when none is supplied.

## Related Issue

N/A — example improvement.

## Motivation and Context

The `role_chaining` example didn't show how to pass an `external_id` through to the underlying account modules. Surfacing it as a variable makes the option discoverable to users reading the example.

## How Has This Been Tested?

Manually deployed a role-chaining / role-chained account pair with an `external_id` set on both modules.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.